### PR TITLE
Update README.md to replace unset package name placeholders

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 0302219c-9df1-4051-a6ae-45f579bcc8d3
 management:
-  docChecksum: 2b8b13b7886148fba855fb99b207f637
+  docChecksum: a1cee417fc19e12f61c8cd7bafcf9c9a
   docVersion: 1.0.0
   speakeasyVersion: 1.622.1
   generationVersion: 2.709.0
-  releaseVersion: 0.3.4
-  configChecksum: 7800aacbd8de5f6e2aa056b965de995f
+  releaseVersion: 0.3.5
+  configChecksum: ce3fc2c04bc03013b67aeb7015e484ef
 features:
   typescript:
     acceptHeaders: 2.81.2

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -27,7 +27,7 @@ generation:
     generateNewTests: true
     skipResponseBodyAssertions: false
 typescript:
-  version: 0.3.4
+  version: 0.3.5
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/.speakeasy/out.openapi.yaml
+++ b/.speakeasy/out.openapi.yaml
@@ -1247,56 +1247,6 @@ paths:
       tags:
         - "Messages"
       x-speakeasy-name-override: "send"
-  "/api/tools/status":
-    get:
-      description: "Get status and authentication information for all available tools and categories"
-      operationId: "getToolsStatus"
-      responses:
-        "200":
-          content:
-            "application/json":
-              schema:
-                properties:
-                  "categories":
-                    additionalProperties:
-                      properties:
-                        "display_name":
-                          description: "User-friendly category name"
-                          type: "string"
-                        "tools":
-                          description: "Available tools in this category"
-                          items:
-                            properties:
-                              "api_key_required":
-                                description: "Whether tool requires API key authentication"
-                                type: "boolean"
-                              "authenticated":
-                                description: "Whether tool is authenticated and ready to use"
-                                type: "boolean"
-                              "description":
-                                description: "Tool description"
-                                type: "string"
-                              "display_name":
-                                description: "User-friendly tool name"
-                                type: "string"
-                              "provider":
-                                description: "Tool provider name"
-                                type: "string"
-                            type: "object"
-                          type: "array"
-                      type: "object"
-                    description: "Map of tool categories and their tools"
-                    type: "object"
-                type: "object"
-          description: "Tools status and authentication information"
-        "500":
-          content:
-            "application/json":
-              schema: {"$ref": "#/components/schemas/ErrorResponse"}
-          description: "Internal server error"
-      summary: "Get tools status"
-      tags:
-        - "Tools"
   "/api/tools/credentials":
     post:
       description: "Store API key for a specific tool provider"
@@ -1410,6 +1360,56 @@ paths:
               schema: {"$ref": "#/components/schemas/ErrorResponse"}
           description: "Internal server error"
       summary: "Delete tool API key"
+      tags:
+        - "Tools"
+  "/api/tools/status":
+    get:
+      description: "Get status and authentication information for all available tools and categories"
+      operationId: "getToolsStatus"
+      responses:
+        "200":
+          content:
+            "application/json":
+              schema:
+                properties:
+                  "categories":
+                    additionalProperties:
+                      properties:
+                        "display_name":
+                          description: "User-friendly category name"
+                          type: "string"
+                        "tools":
+                          description: "Available tools in this category"
+                          items:
+                            properties:
+                              "api_key_required":
+                                description: "Whether tool requires API key authentication"
+                                type: "boolean"
+                              "authenticated":
+                                description: "Whether tool is authenticated and ready to use"
+                                type: "boolean"
+                              "description":
+                                description: "Tool description"
+                                type: "string"
+                              "display_name":
+                                description: "User-friendly tool name"
+                                type: "string"
+                              "provider":
+                                description: "Tool provider name"
+                                type: "string"
+                            type: "object"
+                          type: "array"
+                      type: "object"
+                    description: "Map of tool categories and their tools"
+                    type: "object"
+                type: "object"
+          description: "Tools status and authentication information"
+        "500":
+          content:
+            "application/json":
+              schema: {"$ref": "#/components/schemas/ErrorResponse"}
+          description: "Internal server error"
+      summary: "Get tools status"
       tags:
         - "Tools"
   "/health":

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.622.1
 sources:
     Mix REST API:
         sourceNamespace: mix-rest-api
-        sourceRevisionDigest: sha256:efafafeb1e893d1ec2470e593f5dbffd56e6e3a1789f4e60d1ef883b116228fa
-        sourceBlobDigest: sha256:297d0fc40ea9f47b3a5789cc720f1c4c2c550ce9f0c44ea8cc372c17e9a6bc6f
+        sourceRevisionDigest: sha256:b86e21d187336e16563a1bba3390440ba0ba7c3c3d164a801af764a8ad8cd828
+        sourceBlobDigest: sha256:3d8736eda88268b952d8dbe9a44d3b6262416e523750b3582b316a4304d74d26
         tags:
             - latest
             - 1.0.0
@@ -11,10 +11,10 @@ targets:
     mix-ts-target:
         source: Mix REST API
         sourceNamespace: mix-rest-api
-        sourceRevisionDigest: sha256:efafafeb1e893d1ec2470e593f5dbffd56e6e3a1789f4e60d1ef883b116228fa
-        sourceBlobDigest: sha256:297d0fc40ea9f47b3a5789cc720f1c4c2c550ce9f0c44ea8cc372c17e9a6bc6f
+        sourceRevisionDigest: sha256:b86e21d187336e16563a1bba3390440ba0ba7c3c3d164a801af764a8ad8cd828
+        sourceBlobDigest: sha256:3d8736eda88268b952d8dbe9a44d3b6262416e523750b3582b316a4304d74d26
         codeSamplesNamespace: mix-rest-api-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:af44de67d2f1d95981cede96ce7d73a3dc254178b0868989bf7ddc26eb6b25dc
+        codeSamplesRevisionDigest: sha256:c7b0e6c8bad2401592cee401281e1a56be8301b6dc0fd649707620d66aab1985
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest

--- a/README.md
+++ b/README.md
@@ -50,25 +50,25 @@ The SDK can be installed with either [npm](https://www.npmjs.com/), [pnpm](https
 ### NPM
 
 ```bash
-npm add <UNSET>
+npm add mix-typescript-sdk
 ```
 
 ### PNPM
 
 ```bash
-pnpm add <UNSET>
+pnpm add mix-typescript-sdk
 ```
 
 ### Bun
 
 ```bash
-bun add <UNSET>
+bun add mix-typescript-sdk
 ```
 
 ### Yarn
 
 ```bash
-yarn add <UNSET> zod
+yarn add mix-typescript-sdk zod
 
 # Note that Yarn does not install peer dependencies automatically. You will need
 # to install zod as shown above.
@@ -172,9 +172,9 @@ run();
 
 ### [tools](docs/sdks/tools/README.md)
 
-* [getToolsStatus](docs/sdks/tools/README.md#gettoolsstatus) - Get tools status
 * [storeToolCredentials](docs/sdks/tools/README.md#storetoolcredentials) - Store tool API key
 * [deleteToolCredentials](docs/sdks/tools/README.md#deletetoolcredentials) - Delete tool API key
+* [getToolsStatus](docs/sdks/tools/README.md#gettoolsstatus) - Get tools status
 
 </details>
 <!-- End Available Resources and Operations [operations] -->

--- a/docs/sdks/tools/README.md
+++ b/docs/sdks/tools/README.md
@@ -5,74 +5,9 @@
 
 ### Available Operations
 
-* [getToolsStatus](#gettoolsstatus) - Get tools status
 * [storeToolCredentials](#storetoolcredentials) - Store tool API key
 * [deleteToolCredentials](#deletetoolcredentials) - Delete tool API key
-
-## getToolsStatus
-
-Get status and authentication information for all available tools and categories
-
-### Example Usage
-
-<!-- UsageSnippet language="typescript" operationID="getToolsStatus" method="get" path="/api/tools/status" -->
-```typescript
-import { Mix } from "mix-typescript-sdk";
-
-const mix = new Mix();
-
-async function run() {
-  const result = await mix.tools.getToolsStatus();
-
-  console.log(result);
-}
-
-run();
-```
-
-### Standalone function
-
-The standalone function version of this method:
-
-```typescript
-import { MixCore } from "mix-typescript-sdk/core.js";
-import { toolsGetToolsStatus } from "mix-typescript-sdk/funcs/toolsGetToolsStatus.js";
-
-// Use `MixCore` for best tree-shaking performance.
-// You can create one instance of it to use across an application.
-const mix = new MixCore();
-
-async function run() {
-  const res = await toolsGetToolsStatus(mix);
-  if (res.ok) {
-    const { value: result } = res;
-    console.log(result);
-  } else {
-    console.log("toolsGetToolsStatus failed:", res.error);
-  }
-}
-
-run();
-```
-
-### Parameters
-
-| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
-| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
-| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
-
-### Response
-
-**Promise\<[operations.GetToolsStatusResponse](../../models/operations/gettoolsstatusresponse.md)\>**
-
-### Errors
-
-| Error Type             | Status Code            | Content Type           |
-| ---------------------- | ---------------------- | ---------------------- |
-| errors.ErrorResponse   | 500                    | application/json       |
-| errors.MixDefaultError | 4XX, 5XX               | \*/\*                  |
+* [getToolsStatus](#gettoolsstatus) - Get tools status
 
 ## storeToolCredentials
 
@@ -219,5 +154,70 @@ run();
 | Error Type             | Status Code            | Content Type           |
 | ---------------------- | ---------------------- | ---------------------- |
 | errors.ErrorResponse   | 400, 404               | application/json       |
+| errors.ErrorResponse   | 500                    | application/json       |
+| errors.MixDefaultError | 4XX, 5XX               | \*/\*                  |
+
+## getToolsStatus
+
+Get status and authentication information for all available tools and categories
+
+### Example Usage
+
+<!-- UsageSnippet language="typescript" operationID="getToolsStatus" method="get" path="/api/tools/status" -->
+```typescript
+import { Mix } from "mix-typescript-sdk";
+
+const mix = new Mix();
+
+async function run() {
+  const result = await mix.tools.getToolsStatus();
+
+  console.log(result);
+}
+
+run();
+```
+
+### Standalone function
+
+The standalone function version of this method:
+
+```typescript
+import { MixCore } from "mix-typescript-sdk/core.js";
+import { toolsGetToolsStatus } from "mix-typescript-sdk/funcs/toolsGetToolsStatus.js";
+
+// Use `MixCore` for best tree-shaking performance.
+// You can create one instance of it to use across an application.
+const mix = new MixCore();
+
+async function run() {
+  const res = await toolsGetToolsStatus(mix);
+  if (res.ok) {
+    const { value: result } = res;
+    console.log(result);
+  } else {
+    console.log("toolsGetToolsStatus failed:", res.error);
+  }
+}
+
+run();
+```
+
+### Parameters
+
+| Parameter                                                                                                                                                                      | Type                                                                                                                                                                           | Required                                                                                                                                                                       | Description                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `options`                                                                                                                                                                      | RequestOptions                                                                                                                                                                 | :heavy_minus_sign:                                                                                                                                                             | Used to set various options for making HTTP requests.                                                                                                                          |
+| `options.fetchOptions`                                                                                                                                                         | [RequestInit](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request#options)                                                                                        | :heavy_minus_sign:                                                                                                                                                             | Options that are passed to the underlying HTTP request. This can be used to inject extra headers for examples. All `Request` options, except `method` and `body`, are allowed. |
+| `options.retries`                                                                                                                                                              | [RetryConfig](../../lib/utils/retryconfig.md)                                                                                                                                  | :heavy_minus_sign:                                                                                                                                                             | Enables retrying HTTP requests under certain failure conditions.                                                                                                               |
+
+### Response
+
+**Promise\<[operations.GetToolsStatusResponse](../../models/operations/gettoolsstatusresponse.md)\>**
+
+### Errors
+
+| Error Type             | Status Code            | Content Type           |
+| ---------------------- | ---------------------- | ---------------------- |
 | errors.ErrorResponse   | 500                    | application/json       |
 | errors.MixDefaultError | 4XX, 5XX               | \*/\*                  |

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -17,7 +17,7 @@
       }
     },
     "..": {
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "zod": "^3.20.0"
       },

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "mix-typescript-sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mix-typescript-sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mix-typescript-sdk",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "zod": "^3.20.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mix-typescript-sdk",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "author": "Speakeasy",
   "type": "module",
   "repository": {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -59,7 +59,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "1.0.0",
-  sdkVersion: "0.3.4",
+  sdkVersion: "0.3.5",
   genVersion: "2.709.0",
-  userAgent: "speakeasy-sdk/typescript 0.3.4 2.709.0 1.0.0 mix-typescript-sdk",
+  userAgent: "speakeasy-sdk/typescript 0.3.5 2.709.0 1.0.0 mix-typescript-sdk",
 } as const;

--- a/src/sdk/tools.ts
+++ b/src/sdk/tools.ts
@@ -11,21 +11,6 @@ import { unwrapAsync } from "../types/fp.js";
 
 export class Tools extends ClientSDK {
   /**
-   * Get tools status
-   *
-   * @remarks
-   * Get status and authentication information for all available tools and categories
-   */
-  async getToolsStatus(
-    options?: RequestOptions,
-  ): Promise<operations.GetToolsStatusResponse> {
-    return unwrapAsync(toolsGetToolsStatus(
-      this,
-      options,
-    ));
-  }
-
-  /**
    * Store tool API key
    *
    * @remarks
@@ -55,6 +40,21 @@ export class Tools extends ClientSDK {
     return unwrapAsync(toolsDeleteToolCredentials(
       this,
       request,
+      options,
+    ));
+  }
+
+  /**
+   * Get tools status
+   *
+   * @remarks
+   * Get status and authentication information for all available tools and categories
+   */
+  async getToolsStatus(
+    options?: RequestOptions,
+  ): Promise<operations.GetToolsStatusResponse> {
+    return unwrapAsync(toolsGetToolsStatus(
+      this,
       options,
     ));
   }


### PR DESCRIPTION
- Replace <UNSET> placeholders with actual package name "mix-typescript-sdk" in installation commands
- Update npm, pnpm, bun, and yarn installation examples with correct package name

🤖 Generated with [Claude Code](https://claude.ai/code)