### PR TITLE
fix: correct Speakeasy API key configuration and version references

### DIFF
--- a/.github/workflows/speakeasy-sdk-generation.yml
+++ b/.github/workflows/speakeasy-sdk-generation.yml
@@ -32,29 +32,22 @@ jobs:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
       
-      - name: Install Speakeasy CLI
-        uses: speakeasy-api/sdk-generation-action@v15
-        with:
-          speakeasy_version: latest
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          
       - name: Generate SDK
         uses: speakeasy-api/sdk-generation-action@v15
         with:
           speakeasy_version: latest
-          speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-          openapi_doc_location: ../mix/mix_sdk/openapi.json
-          github_pat: ${{ secrets.GITHUB_TOKEN }}
-          action: all
           mode: direct
+          action: all
+        env:
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Setup Git
         run: |
           git config --global user.name "speakeasy-bot"
           git config --global user.email "bot@speakeasy.com"
           
-      - name: Check for changes
+      - name: Check for changes and get version
         id: changes
         run: |
           if git diff --quiet; then
@@ -62,6 +55,7 @@ jobs:
           else
             echo "changes=true" >> $GITHUB_OUTPUT
           fi
+          echo "version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
           
       - name: Commit and push changes
         if: steps.changes.outputs.changes == 'true'
@@ -81,8 +75,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          release_name: Release v${{ steps.version.outputs.version }}
+          tag_name: v${{ steps.changes.outputs.version }}
+          release_name: Release v${{ steps.changes.outputs.version }}
           body: |
             ## Changes
             - Auto-generated SDK from latest OpenAPI specification
@@ -116,6 +110,6 @@ jobs:
           event-type: sdk-updated
           client-payload: |
             {
-              "sdk_version": "${{ steps.version.outputs.version }}",
+              "sdk_version": "${{ steps.changes.outputs.version }}",
               "spec_url": "https://spec.speakeasy.com/recreate/mix/mix-rest-api"
             }


### PR DESCRIPTION
- Use env section for SPEAKEASY_API_KEY instead of with parameters
- Fix missing version step reference
- Simplify action configuration to use workflow.yaml auto-detection

🤖 Generated with Claude Code