### PR TITLE
fix: remove invalid 'action: all' parameter from Speakeasy workflow

### DIFF
--- a/.github/workflows/speakeasy-sdk-generation.yml
+++ b/.github/workflows/speakeasy-sdk-generation.yml
@@ -37,7 +37,6 @@ jobs:
         with:
           speakeasy_version: latest
           mode: direct
-          action: all
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The Speakeasy GitHub Action doesn't support 'action: all' parameter.
Using default behavior with mode: direct instead.

🤖 Generated with Claude Code